### PR TITLE
Implement version

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,7 +18,7 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("version: %s-%s (%s)\n", version.Version, version.Revision, version.BuildDate)
+		fmt.Printf("version: %s-%s (%s)\n", version.GetVersion(), version.GetRevision(), version.GetBuildDate())
 	},
 }
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,69 @@
 package version
 
+import (
+	"runtime/debug"
+)
+
 var (
 	Version   = "DEV"
 	Revision  = "unset"
 	BuildDate = ""
 )
+
+const (
+	defaultVersion   = "DEV"
+	defaultRevision  = "unset"
+	defaultBuildDate = ""
+)
+
+func GetVersion() string {
+	if Version != defaultVersion {
+		return Version
+	}
+
+	// if go install
+	if buildInfo, ok := debug.ReadBuildInfo(); ok && buildInfo.Main.Version != "" {
+		return buildInfo.Main.Version
+	}
+
+	return defaultVersion
+}
+
+func GetRevision() string {
+	if Revision != defaultRevision {
+		return Revision
+	}
+
+	// if go install
+	if rev, ok := getBuildSettings("vcs.revision"); ok {
+		return rev
+	}
+
+	return defaultRevision
+}
+
+func GetBuildDate() string {
+	if BuildDate != defaultBuildDate {
+		return BuildDate
+	}
+
+	// if go install
+	if date, ok := getBuildSettings("vcs.time"); ok {
+		return date
+	}
+
+	return defaultBuildDate
+}
+
+func getBuildSettings(key string) (string, bool) {
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", false
+	}
+	for _, v := range buildInfo.Settings {
+		if v.Key == key {
+			return v.Value, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
```
kmdkuk in ~/go/sr/gi/km/goct on  implement-version via 🐹 v1.18.3 
❯ make build 
go build -trimpath -ldflags "-X github.com/kmdkuk/goct/pkg/version.Version=v0.0.3 -X github.com/kmdkuk/goct/pkg/version.BuildDate=2022-07-09 -X github.com/kmdkuk/goct/pkg/version.Revision=3d2c38b " -o /home/kmdkuk/go/src/github.com/kmdkuk/goct/bin/ .

kmdkuk in ~/go/sr/gi/km/goct on  implement-version via 🐹 v1.18.3 
❯ ./bin/goct version
version: v0.0.3-3d2c38b (2022-07-09)

kmdkuk in ~/go/sr/gi/km/goct on  implement-version via 🐹 v1.18.3 
❯ go run main.go version
version: DEV-unset ()

kmdkuk in ~/go/sr/gi/km/goct on  implement-version via 🐹 v1.18.3 
❯ go install .

kmdkuk in ~/go/sr/gi/km/goct on  implement-version via 🐹 v1.18.3 
❯ goct version
version: (devel)-3d2c38bed66c8ff7ba0b5c9181bc64940d1e082f (2022-07-09T07:59:31Z)
```

Signed-off-by: kouki <kouworld0123@gmail.com>